### PR TITLE
Add stars scale and color controls

### DIFF
--- a/sky.gdshader
+++ b/sky.gdshader
@@ -48,6 +48,8 @@ group_uniforms stars;
 	// Stars should be at black background
 	uniform sampler2D stars_texture : filter_linear_mipmap, hint_default_black;
 	uniform float stars_speed : hint_range( 0.0, 20.0, 0.01 ) = 1.0;
+	uniform float stars_scale : hint_range(0.1, 3.0, 0.01) = 1.0;
+	uniform float stars_opacity : hint_range(0.1, 1.0, 0.01) = 1.0;
 
 group_uniforms settings;
 	uniform float overwritten_time = 0.0;
@@ -239,12 +241,12 @@ void sky()
 		vec2 _stars_uv = vec2(
 			_sky_uv.x * _stars_speed_cos - _sky_uv.y * _stars_speed_sin,
 			_sky_uv.x * _stars_speed_sin + _sky_uv.y * _stars_speed_cos
-		);
+		) * stars_scale;
 		// Stars texture
 		vec3 _stars_color = texture( stars_texture, _stars_uv ).rgb * -LIGHT0_DIRECTION.y;
 		// Hiding stars behind the moon
 		_stars_color *= 1.0 - _moon_amount;
-		COLOR += _stars_color;
+		COLOR += _stars_color * stars_opacity;
 	}
 
 	//////////////////// CLOUDS ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Hi, I've added two variables to have more control over the stars.

Stars scale allows to change the size of stars and theirs density:

Scale 1.0:
![image](https://github.com/krzmig/godot-simple-sky-project/assets/26604491/e9c8d96a-52d8-45d4-a993-ebb9652c4b1e)

Scale 2.5:
![image](https://github.com/krzmig/godot-simple-sky-project/assets/26604491/8cd965d9-7d1c-4c2d-9949-00559b00241a)


And opacity 1.0:
![image](https://github.com/krzmig/godot-simple-sky-project/assets/26604491/b61c757a-b445-45e9-88a8-24e110a0fbab)

Opacity 0.4: 
![image](https://github.com/krzmig/godot-simple-sky-project/assets/26604491/8914de25-276b-4747-aa23-af3a20107ae7)
